### PR TITLE
Fix 5.7 incompatibility

### DIFF
--- a/pyuic/uic/widget-plugins/qtwebengine.py
+++ b/pyuic/uic/widget-plugins/qtwebengine.py
@@ -1,5 +1,6 @@
 #############################################################################
 ##
+## Copyright (C) 2016 Dmitry Luciv
 ## Copyright (C) 2014 Riverbank Computing Limited.
 ## Copyright (C) 2006 Thorsten Marek.
 ## All right reserved.
@@ -48,4 +49,4 @@ pluginType = MODULE
 # "import A".  If "module" is "A[.B].C", the code generator will write
 # "from A[.B] import C".  Each entry in "widget_list" must be unique.
 def moduleInformation():
-    return "PyQt5.QtWebKitWidgets", ("QWebView", )
+    return "PyQt5.QtWebEngineWidgets", ("QWebEngineView", )

--- a/pyuic/uic/widget-plugins/qtwebkit.py
+++ b/pyuic/uic/widget-plugins/qtwebkit.py
@@ -48,4 +48,4 @@ pluginType = MODULE
 # "import A".  If "module" is "A[.B].C", the code generator will write
 # "from A[.B] import C".  Each entry in "widget_list" must be unique.
 def moduleInformation():
-    return "PyQt5.QtWebKitWidgets", ("QWebView", )
+    return "PyQt5.QtWebEngineWidgets", ("QWebEngineView", )


### PR DESCRIPTION
I am porting my PyQt application to PyQt 5.7.

Application uses .ui files generated by QtCreator as follows:

```
def ui_class(name):
    return uic.loadUiType(os.path.join(os.path.dirname(os.path.realpath(__file__)), 'qtui', name))[0]

class ElemBrowserTab(QtWidgets.QWidget, ui_class('element_browser_tab.ui')):
    def __init__(self, parent, uri, stats, src="", fn=""):
        QtWidgets.QWidget.__init__(self, parent)
        self.setupUi(self)
...
```

Among other (expected) 5.5 -> 5.7 incompatibilities, it crashes with:

```
PyQt5.uic.exceptions.NoSuchWidgetError: Unknown Qt widget: QWebEngineView
```

Proposed change helps me.

I guess it is a place to fix something.
Thank you!
