### PR TITLE
prevent out-of-bounds error in editable tree model example

### DIFF
--- a/examples/itemviews/editabletreemodel/editabletreemodel.py
+++ b/examples/itemviews/editabletreemodel/editabletreemodel.py
@@ -57,6 +57,8 @@ class TreeItem(object):
         self.childItems = []
 
     def child(self, row):
+        if row < 0 or row >= len(self.childItems):
+            return None
         return self.childItems[row]
 
     def childCount(self):
@@ -71,6 +73,8 @@ class TreeItem(object):
         return len(self.itemData)
 
     def data(self, column):
+        if column < 0 or column >= len(self.itemData):
+            return None
         return self.itemData[column]
 
     def insertChildren(self, position, count, columns):


### PR DESCRIPTION
While playing with and adjusting the editable tree model example for one of my [projects](https://github.com/rknuus/INCode) I noticed an out-of-bounds error crashing the application. Even though I don't recall how exactly I reproduced it the suggested bugfix prevents 'out of range' exceptions by checking preconditions similar to other methods.