### PR TITLE
QtQml: Double the amount of registered singleton types

### DIFF
--- a/qpy/QtQml/qpyqml_register_singleton_type.cpp
+++ b/qpy/QtQml/qpyqml_register_singleton_type.cpp
@@ -36,7 +36,7 @@ static int register_type(QQmlPrivate::RegisterSingletonType *rt);
 
 
 // The number of types that can be registered.
-const int NrOfTypes = 30;
+const int NrOfTypes = 60;
 
 
 // The registration data for the proxy types.


### PR DESCRIPTION
Feature-rich and modern applications might need to register more than 30 types.
Let's double it.

PS: It would be much better, if we could modify the array(?) on init. So, depending on the application that is running Qt, a custom size can be set.