### PR TITLE
Fixed conditional in simpletreemodel example

### DIFF
--- a/examples/itemviews/editabletreemodel/editabletreemodel.py
+++ b/examples/itemviews/editabletreemodel/editabletreemodel.py
@@ -264,7 +264,7 @@ class TreeModel(QAbstractItemModel):
         while number < len(lines):
             position = 0
             while position < len(lines[number]):
-                if lines[number][position] != " ":
+                if lines[number][position] != b' ':
                     break
                 position += 1
 

--- a/examples/itemviews/simpletreemodel/simpletreemodel.py
+++ b/examples/itemviews/simpletreemodel/simpletreemodel.py
@@ -165,7 +165,7 @@ class TreeModel(QAbstractItemModel):
         while number < len(lines):
             position = 0
             while position < len(lines[number]):
-                if lines[number][position] != ' ':
+                if lines[number][position] != b' ':
                     break
                 position += 1
 


### PR DESCRIPTION
lines[number][position] contains a bytes literal, for example the first line in default.txt would be: "b'Getting Started\t\t\t\tHow to familiarize yourself with Qt Designer'". If we compared this line with a string containing a whitespace (' '), that would evaluate false. This caused the nested structure to fail (all items were siblings of each other being only children of root item).