### PR TITLE
docs: Fix a few typos

### DIFF
--- a/pylupdate/sametexth.cpp
+++ b/pylupdate/sametexth.cpp
@@ -50,7 +50,7 @@ typedef QList<MetaTranslatorMessage> TML;
 /*
   Augments a MetaTranslator with trivially derived translations.
 
-  For example, if "Enabled:" is consistendly translated as "Eingeschaltet:" no
+  For example, if "Enabled:" is consistently translated as "Eingeschaltet:" no
   matter the context or the comment, "Eingeschaltet:" is added as the
   translation of any untranslated "Enabled:" text and is marked Unfinished.
 

--- a/qpy/QtCore/qpycore_chimera.cpp
+++ b/qpy/QtCore/qpycore_chimera.cpp
@@ -1316,7 +1316,7 @@ PyObject *Chimera::toPyObject(const QVariant &var) const
 }
 
 
-// Convert a C++ object at an arbitary address to Python.
+// Convert a C++ object at an arbitrary address to Python.
 PyObject *Chimera::toPyObject(void *cpp) const
 {
     if (_metatype == PyQt_PyObject::metatype)

--- a/qpy/QtCore/qpycore_chimera.h
+++ b/qpy/QtCore/qpycore_chimera.h
@@ -202,7 +202,7 @@ public:
     // Convert a QVariant to a Python object.
     PyObject *toPyObject(const QVariant &var) const;
 
-    // Convert a C++ object at an arbitary address to a Python object.
+    // Convert a C++ object at an arbitrary address to a Python object.
     PyObject *toPyObject(void *cpp) const;
 
     // Convert a QVariant to a Python object based on the type of the object.

--- a/qpy/QtCore/qpycore_pyqtsignal.cpp
+++ b/qpy/QtCore/qpycore_pyqtsignal.cpp
@@ -722,7 +722,7 @@ int qpycore_get_lazy_attr(const sipTypeDef *td, PyObject *dict)
     const pyqt5QtSignal *sigs = reinterpret_cast<const pyqt5ClassPluginDef *>(
             sipTypePluginData(td))->qt_signals;
 
-    // Handle the trvial case.
+    // Handle the trivial case.
     if (!sigs)
         return 0;
 

--- a/qpy/pylupdate/sametexth.cpp
+++ b/qpy/pylupdate/sametexth.cpp
@@ -50,7 +50,7 @@ typedef QList<MetaTranslatorMessage> TML;
 /*
   Augments a MetaTranslator with trivially derived translations.
 
-  For example, if "Enabled:" is consistendly translated as "Eingeschaltet:" no
+  For example, if "Enabled:" is consistently translated as "Eingeschaltet:" no
   matter the context or the comment, "Eingeschaltet:" is added as the
   translation of any untranslated "Enabled:" text and is marked Unfinished.
 


### PR DESCRIPTION
There are small typos in:
- pylupdate/sametexth.cpp
- qpy/QtCore/qpycore_chimera.cpp
- qpy/QtCore/qpycore_chimera.h
- qpy/QtCore/qpycore_pyqtsignal.cpp
- qpy/pylupdate/sametexth.cpp

Fixes:
- Should read `consistently` rather than `consistendly`.
- Should read `arbitrary` rather than `arbitary`.
- Should read `trivial` rather than `trvial`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md